### PR TITLE
Add more calculation options: tree building and proof generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/txaty/go-merkletree.svg)](https://pkg.go.dev/github.com/txaty/go-merkletree)
 [![Go Report Card](https://goreportcard.com/badge/github.com/txaty/go-merkletree)](https://goreportcard.com/report/github.com/txaty/go-merkletree)
-![Coverage](https://img.shields.io/badge/Coverage-87.6%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-82.9%25-brightgreen)
 
 High performance Merkle Tree Computation in Go (supports parallelization).
 

--- a/merkle_tree.go
+++ b/merkle_tree.go
@@ -4,131 +4,234 @@ import (
 	"bytes"
 	"crypto/rand"
 	"crypto/sha256"
+	"errors"
 	"math"
+	"runtime"
 	"sync"
 
 	"golang.org/x/sync/errgroup"
 )
 
 const (
-	// default hash result length, using SHA256
+	// Default hash result length using SHA256.
 	defaultHashLen = 32
+	// ModeProofGen is the proof generation configuration mode.
+	ModeProofGen ModeType = iota
+	// ModeTreeBuild is the tree building configuration mode.
+	ModeTreeBuild
+	// ModeProofGenAndTreeBuild is the proof generation and tree building configuration mode.
+	ModeProofGenAndTreeBuild
 )
 
-// DataBlock is the interface of input data blocks to generate the Merkle Tree
+// ModeType is the type in the Merkle Tree configuration indicating what operations are performed.
+type ModeType int
+
+// DataBlock is the interface of input data blocks to generate the Merkle Tree.
 type DataBlock interface {
 	Serialize() ([]byte, error)
 }
 
-// Config is the configuration of Merkle Tree
+// HashFuncType is the signature of the hash functions used for Merkle Tree generation.
+type HashFuncType func([]byte) ([]byte, error)
+
+// Config is the configuration of Merkle Tree.
 type Config struct {
-	// customizable hash function used for tree generation
-	HashFunc func([]byte) ([]byte, error)
-	// if true, the generation runs in parallel,
-	// this increase the performance for the calculation of large number of data blocks, e.g. over 10,000 blocks
+	// Customizable hash function used for tree generation.
+	HashFunc HashFuncType
+	// If true, the generation runs in parallel, otherwise runs without parallelization.
+	// This increase the performance for the calculation of large number of data blocks, e.g. over 10,000 blocks.
 	RunInParallel bool
-	// number of goroutines run in parallel
+	// Number of goroutines run in parallel.
 	NumRoutines int
-	// if true, then the odd node situation is handled by duplicating the previous node
-	// otherwise, generate a dummy node with random hash value
-	AllowDuplicates bool
+	// If true, generate a dummy node with random hash value.
+	// Otherwise, then the odd node situation is handled by duplicating the previous node.
+	NoDuplicates bool
+	// Mode of the Merkle Tree generation.
+	Mode ModeType
 }
 
 // MerkleTree implements the Merkle Tree structure
 type MerkleTree struct {
-	*Config            // Merkle Tree configuration
-	Root      []byte   // Merkle root hash
-	Leaves    [][]byte // Merkle Tree leaves, i.e. the hashes of the data blocks for tree generation
-	Proofs    []*Proof // proofs to the data blocks generated during the tree building process
-	treeDepth int      // the Merkle Tree depth
+	// Config is the Merkle Tree configuration
+	*Config
+	// Root is the Merkle root hash
+	Root []byte
+	// Leaves are Merkle Tree leaves, i.e. the hashes of the data blocks for tree generation
+	Leaves [][]byte
+	// Proofs are proofs to the data blocks generated during the tree building process
+	Proofs []*Proof
+	// Depth is the Merkle Tree depth
+	Depth uint32
+	// tree is the Merkle Tree structure, only available when config mode is ModeTreeBuild or ModeProofGenAndTreeBuild
+	tree [][][]byte
+	// leafMap is the map of the leaf hash to the index in the Tree slice,
+	// only available when config mode is ModeTreeBuild or ModeProofGenAndTreeBuild
+	leafMap sync.Map
 }
 
-// Proof implements the Merkle Tree proof
+// Proof implements the Merkle Tree proof.
 type Proof struct {
-	Path      uint16   // path variable indicating whether the neighbor is on the left or right
-	Neighbors [][]byte // neighbor nodes near the path
+	Path     uint32   // path variable indicating whether the neighbor is on the left or right
+	Siblings [][]byte // sibling nodes to the Merkle Tree path of the data block
 }
 
-// New generates a new Merkle Tree with specified configuration
+// New generates a new Merkle Tree with specified configuration.
 func New(config *Config, blocks []DataBlock) (m *MerkleTree, err error) {
 	if len(blocks) <= 1 {
-		return nil, nil
+		return nil, errors.New("the number of data blocks must be greater than 1")
 	}
 	if config == nil {
-		config = &Config{}
+		config = new(Config)
 	}
 	if config.HashFunc == nil {
 		config.HashFunc = defaultHashFunc
 	}
+	// if the configuration mode is not set, then set it to ModeProofGen by default
+	if config.Mode == 0 {
+		config.Mode = ModeProofGen
+	}
+	if config.RunInParallel && config.NumRoutines == 0 {
+		config.NumRoutines = runtime.NumCPU()
+	}
 	m = &MerkleTree{
 		Config: config,
 	}
-	m.treeDepth = calTreeDepth(len(blocks))
-	if m.RunInParallel {
-		m.Leaves, err = generateLeavesParallel(blocks, m.HashFunc, m.Config.NumRoutines)
+	m.Depth = calTreeDepth(len(blocks))
+	if m.Mode == ModeProofGen {
+		if m.RunInParallel {
+			m.Leaves, err = leafGenParal(blocks, m.HashFunc, m.NumRoutines)
+			if err != nil {
+				return
+			}
+			err = m.proofGenParal()
+			return
+		}
+		m.Leaves, err = leafGen(blocks, m.HashFunc)
 		if err != nil {
 			return
 		}
-		m.Root, err = m.buildTreeParallel()
-	} else {
-		m.Leaves, err = generateLeaves(blocks, m.HashFunc)
+		err = m.proofGen()
+		return
+	}
+	if m.Mode == ModeTreeBuild {
+		if m.RunInParallel {
+			panic("not implemented")
+		}
+		m.Leaves, err = leafGen(blocks, m.HashFunc)
 		if err != nil {
 			return
 		}
-		m.Root, err = m.buildTree()
+		err = m.buildTree()
+		return
+	}
+	if m.Mode == ModeProofGenAndTreeBuild {
+		panic("not implemented")
 	}
 	return
 }
 
-func calTreeDepth(blockLen int) int {
+// calTreeDepth calculates the tree depth,
+// the tree depth is then used to declare the capacity of the proof slices.
+func calTreeDepth(blockLen int) uint32 {
 	log2BlockLen := math.Log2(float64(blockLen))
-	return int(math.Round(log2BlockLen) + 0.499)
+	// check if log2BlockLen is an integer
+	if log2BlockLen != math.Trunc(log2BlockLen) {
+		return uint32(log2BlockLen) + 1
+	}
+	return uint32(log2BlockLen)
 }
 
-func (m *MerkleTree) buildTree() (root []byte, err error) {
+func (m *MerkleTree) proofGen() (err error) {
 	numLeaves := len(m.Leaves)
 	m.Proofs = make([]*Proof, numLeaves)
 	for i := 0; i < numLeaves; i++ {
 		m.Proofs[i] = new(Proof)
-		m.Proofs[i].Neighbors = make([][]byte, 0, m.treeDepth)
+		m.Proofs[i].Siblings = make([][]byte, 0, m.Depth)
 	}
 	var (
-		step    = 1
-		prevLen int
+		step, prevLen int
 	)
 	buf := make([][]byte, numLeaves)
 	copy(buf, m.Leaves)
 	buf, prevLen, err = m.fixOdd(buf, numLeaves)
 	if err != nil {
-		return nil, err
+		return
 	}
-	m.assignProofs(buf, numLeaves, 0)
+	m.updateProofs(buf, numLeaves, 0)
 	for {
-		buf, prevLen, err = m.fixOdd(buf, prevLen)
-		if err != nil {
-			return nil, err
-		}
 		for idx := 0; idx < prevLen; idx += 2 {
-			appendHash := append(buf[idx], buf[idx+1]...)
-			buf[idx/2], err = m.HashFunc(appendHash)
+			buf[idx>>1], err = m.HashFunc(append(buf[idx], buf[idx+1]...))
 			if err != nil {
-				return nil, err
+				return
 			}
 		}
-		prevLen /= 2
+		prevLen >>= 1
 		if prevLen == 1 {
 			break
-		} else {
-			buf, prevLen, err = m.fixOdd(buf, prevLen)
-			if err != nil {
-				return nil, err
-			}
 		}
-		m.assignProofs(buf, prevLen, step)
+		buf, prevLen, err = m.fixOdd(buf, prevLen)
+		if err != nil {
+			return
+		}
 		step++
+		m.updateProofs(buf, prevLen, step)
 	}
-	root = buf[0]
-	m.Root = root
+	m.Root = buf[0]
+	return
+}
+
+func (m *MerkleTree) proofGenParal() (err error) {
+	numRoutines := m.NumRoutines
+	numLeaves := len(m.Leaves)
+	m.Proofs = make([]*Proof, numLeaves)
+	for i := 0; i < numLeaves; i++ {
+		m.Proofs[i] = new(Proof)
+	}
+	var (
+		step, prevLen int
+	)
+	buf1 := make([][]byte, numLeaves)
+	copy(buf1, m.Leaves)
+	buf1, prevLen, err = m.fixOdd(buf1, numLeaves)
+	if err != nil {
+		return
+	}
+	buf2 := make([][]byte, prevLen>>1)
+	m.updateProofsParal(buf1, numLeaves, 0)
+	for {
+		if err != nil {
+			return
+		}
+		g := new(errgroup.Group)
+		for i := 0; i < numRoutines && i < prevLen; i++ {
+			idx := i << 1
+			g.Go(func() error {
+				for j := idx; j < prevLen; j += numRoutines << 1 {
+					newHash, err := m.HashFunc(append(buf1[j], buf1[j+1]...))
+					if err != nil {
+						return err
+					}
+					buf2[j>>1] = newHash
+				}
+				return nil
+			})
+		}
+		if err = g.Wait(); err != nil {
+			return
+		}
+		buf1, buf2 = buf2, buf1
+		prevLen >>= 1
+		if prevLen == 1 {
+			break
+		}
+		buf1, prevLen, err = m.fixOdd(buf1, prevLen)
+		if err != nil {
+			return
+		}
+		step++
+		m.updateProofsParal(buf1, prevLen, step)
+	}
+	m.Root = buf1[0]
 	return
 }
 
@@ -138,14 +241,14 @@ func (m *MerkleTree) buildTree() (root []byte, err error) {
 func (m *MerkleTree) fixOdd(buf [][]byte, prevLen int) ([][]byte, int, error) {
 	if prevLen%2 == 1 {
 		var appendNode []byte
-		if m.AllowDuplicates {
-			appendNode = buf[prevLen-1]
-		} else {
+		if m.NoDuplicates {
 			var err error
 			appendNode, err = getDummyHash()
 			if err != nil {
 				return nil, 0, err
 			}
+		} else {
+			appendNode = buf[prevLen-1]
 		}
 		if len(buf) <= prevLen+1 {
 			buf = append(buf, appendNode)
@@ -157,17 +260,17 @@ func (m *MerkleTree) fixOdd(buf [][]byte, prevLen int) ([][]byte, int, error) {
 	return buf, prevLen, nil
 }
 
-func (m *MerkleTree) assignProofs(buf [][]byte, bufLen, step int) {
+func (m *MerkleTree) updateProofs(buf [][]byte, bufLen, step int) {
 	if bufLen < 2 {
 		return
 	}
 	batch := 1 << step
 	for i := 0; i < bufLen; i += 2 {
-		m.assignPairProof(buf, bufLen, i, batch, step)
+		m.updatePairProof(buf, bufLen, i, batch, step)
 	}
 }
 
-func (m *MerkleTree) assignProofsParallel(buf [][]byte, bufLen, step int) {
+func (m *MerkleTree) updateProofsParal(buf [][]byte, bufLen, step int) {
 	numRoutines := m.NumRoutines
 	if bufLen < 2 {
 		return
@@ -175,19 +278,19 @@ func (m *MerkleTree) assignProofsParallel(buf [][]byte, bufLen, step int) {
 	batch := 1 << step
 	wg := new(sync.WaitGroup)
 	for i := 0; i < numRoutines; i++ {
-		idx := 2 * i
+		idx := i << 1
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for j := idx; j < bufLen; j += 2 * numRoutines {
-				m.assignPairProof(buf, bufLen, j, batch, step)
+			for j := idx; j < bufLen; j += numRoutines << 1 {
+				m.updatePairProof(buf, bufLen, j, batch, step)
 			}
 		}()
 	}
 	wg.Wait()
 }
 
-func (m *MerkleTree) assignPairProof(buf [][]byte, bufLen, idx, batch, step int) {
+func (m *MerkleTree) updatePairProof(buf [][]byte, bufLen, idx, batch, step int) {
 	if bufLen < 2 {
 		return
 	}
@@ -198,7 +301,7 @@ func (m *MerkleTree) assignPairProof(buf [][]byte, bufLen, idx, batch, step int)
 	}
 	for j := start; j < end; j++ {
 		m.Proofs[j].Path += 1 << step
-		m.Proofs[j].Neighbors = append(m.Proofs[j].Neighbors, buf[idx+1])
+		m.Proofs[j].Siblings = append(m.Proofs[j].Siblings, buf[idx+1])
 	}
 	start = (idx + 1) * batch
 	end = start + batch
@@ -206,70 +309,11 @@ func (m *MerkleTree) assignPairProof(buf [][]byte, bufLen, idx, batch, step int)
 		end = len(m.Proofs)
 	}
 	for j := start; j < end; j++ {
-		m.Proofs[j].Neighbors = append(m.Proofs[j].Neighbors, buf[idx])
+		m.Proofs[j].Siblings = append(m.Proofs[j].Siblings, buf[idx])
 	}
 }
 
-func (m *MerkleTree) buildTreeParallel() (root []byte, err error) {
-	numRoutines := m.NumRoutines
-	numLeaves := len(m.Leaves)
-	m.Proofs = make([]*Proof, numLeaves)
-	for i := 0; i < numLeaves; i++ {
-		m.Proofs[i] = new(Proof)
-	}
-	var (
-		step    = 1
-		prevLen int
-	)
-	buf1 := make([][]byte, numLeaves)
-	copy(buf1, m.Leaves)
-	buf1, prevLen, err = m.fixOdd(buf1, numLeaves)
-	if err != nil {
-		return nil, err
-	}
-	buf2 := make([][]byte, prevLen/2)
-	m.assignProofsParallel(buf1, numLeaves, 0)
-	for {
-		buf1, prevLen, err = m.fixOdd(buf1, prevLen)
-		if err != nil {
-			return nil, err
-		}
-		g := new(errgroup.Group)
-		for i := 0; i < numRoutines && i < prevLen; i++ {
-			idx := 2 * i
-			g.Go(func() error {
-				for j := idx; j < prevLen; j += 2 * numRoutines {
-					newHash, err := m.HashFunc(append(buf1[j], buf1[j+1]...))
-					if err != nil {
-						return err
-					}
-					buf2[j/2] = newHash
-				}
-				return nil
-			})
-		}
-		if err := g.Wait(); err != nil {
-			return nil, err
-		}
-		buf1, buf2 = buf2, buf1
-		prevLen /= 2
-		if prevLen == 1 {
-			break
-		} else {
-			buf1, prevLen, err = m.fixOdd(buf1, prevLen)
-			if err != nil {
-				return nil, err
-			}
-		}
-		m.assignProofsParallel(buf1, prevLen, step)
-		step++
-	}
-	root = buf1[0]
-	m.Root = root
-	return
-}
-
-// generate a dummy
+// generate a dummy hash to make odd-length buffer even
 func getDummyHash() ([]byte, error) {
 	dummyBytes := make([]byte, defaultHashLen)
 	_, err := rand.Read(dummyBytes)
@@ -279,14 +323,15 @@ func getDummyHash() ([]byte, error) {
 	return dummyBytes, nil
 }
 
-// default hash function using SHA256
+// defaultHashFunc is used when no user hash function is specified.
+// It implements SHA256 hash function.
 func defaultHashFunc(data []byte) ([]byte, error) {
 	sha256Func := sha256.New()
 	sha256Func.Write(data)
 	return sha256Func.Sum(nil), nil
 }
 
-func generateLeaves(blocks []DataBlock, hashFunc func([]byte) ([]byte, error)) ([][]byte, error) {
+func leafGen(blocks []DataBlock, hashFunc HashFuncType) ([][]byte, error) {
 	var (
 		lenLeaves = len(blocks)
 		leaves    = make([][]byte, lenLeaves)
@@ -305,8 +350,7 @@ func generateLeaves(blocks []DataBlock, hashFunc func([]byte) ([]byte, error)) (
 	return leaves, nil
 }
 
-func generateLeavesParallel(blocks []DataBlock,
-	hashFunc func([]byte) ([]byte, error), numRoutines int) ([][]byte, error) {
+func leafGenParal(blocks []DataBlock, hashFunc HashFuncType, numRoutines int) ([][]byte, error) {
 	var (
 		lenLeaves = len(blocks)
 		leaves    = make([][]byte, lenLeaves)
@@ -336,14 +380,50 @@ func generateLeavesParallel(blocks []DataBlock,
 	return leaves, nil
 }
 
+func (m *MerkleTree) buildTree() (err error) {
+	numLeaves := len(m.Leaves)
+	m.leafMap = sync.Map{}
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < numLeaves; i++ {
+			m.leafMap.Store(string(m.Leaves[i]), i)
+		}
+	}()
+	m.tree = make([][][]byte, m.Depth+1)
+	m.tree[0] = make([][]byte, numLeaves)
+	copy(m.tree[0], m.Leaves)
+	var prevLen int
+	m.tree[0], prevLen, err = m.fixOdd(m.tree[0], numLeaves)
+	for i := uint32(0); i < m.Depth; i++ {
+		m.tree[i+1] = make([][]byte, prevLen>>1)
+		if err != nil {
+			return
+		}
+		for j := 0; j < prevLen; j += 2 {
+			m.tree[i+1][j>>1], err = m.HashFunc(append(m.tree[i][j], m.tree[i][j+1]...))
+			if err != nil {
+				return
+			}
+		}
+		m.tree[i+1], prevLen, err = m.fixOdd(m.tree[i+1], len(m.tree[i+1]))
+	}
+	m.Root = m.tree[m.Depth][0]
+	wg.Wait()
+	return
+}
+
 // Verify verifies the data block with the Merkle Tree proof
 func (m *MerkleTree) Verify(dataBlock DataBlock, proof *Proof) (bool, error) {
 	return Verify(dataBlock, proof, m.Root, m.HashFunc)
 }
 
 // Verify verifies the data block with the Merkle Tree proof and Merkle root hash
-func Verify(dataBlock DataBlock, proof *Proof, root []byte,
-	hashFunc func([]byte) ([]byte, error)) (bool, error) {
+func Verify(dataBlock DataBlock, proof *Proof, root []byte, hashFunc HashFuncType) (bool, error) {
+	if proof == nil {
+		return false, errors.New("proof is nil")
+	}
 	if hashFunc == nil {
 		hashFunc = defaultHashFunc
 	}
@@ -359,7 +439,7 @@ func Verify(dataBlock DataBlock, proof *Proof, root []byte,
 		return false, err
 	}
 	path := proof.Path
-	for _, n := range proof.Neighbors {
+	for _, n := range proof.Siblings {
 		if path&1 == 1 {
 			hash, err = hashFunc(append(hash, n...))
 		} else {
@@ -371,4 +451,43 @@ func Verify(dataBlock DataBlock, proof *Proof, root []byte,
 		path >>= 1
 	}
 	return bytes.Equal(hash, root), nil
+}
+
+// GenerateProof generates the Merkle proof for a data block with the Merkle Tree structure generated beforehand.
+// The method is only available when the configuration mode is ModeTreeBuild or ModeProofGenAndTreeBuild.
+// In ModeProofGen, proofs for all the data blocks are already generated, and the Merkle Tree structure is not cached.
+func (m *MerkleTree) GenerateProof(dataBlock DataBlock) (*Proof, error) {
+	if m.Mode != ModeTreeBuild && m.Mode != ModeProofGenAndTreeBuild {
+		return nil, errors.New("merkle Tree is not in built, could not generate proof by this method")
+	}
+	blockByte, err := dataBlock.Serialize()
+	if err != nil {
+		return nil, err
+	}
+	blockHash, err := m.HashFunc(blockByte)
+	if err != nil {
+		return nil, err
+	}
+	val, ok := m.leafMap.Load(string(blockHash))
+	if !ok {
+		return nil, errors.New("data block is not a member of the Merkle Tree")
+	}
+	var (
+		idx      = val.(int)
+		path     uint32
+		siblings = make([][]byte, m.Depth)
+	)
+	for i := uint32(0); i < m.Depth; i++ {
+		if idx%2 == 1 {
+			siblings[i] = m.tree[i][idx-1]
+		} else {
+			path += 1 << i
+			siblings[i] = m.tree[i][idx+1]
+		}
+		idx >>= 1
+	}
+	return &Proof{
+		Path:     path,
+		Siblings: siblings,
+	}, nil
 }

--- a/merkle_tree_test.go
+++ b/merkle_tree_test.go
@@ -1,7 +1,10 @@
 package merkletree
 
 import (
+	"bytes"
+	"fmt"
 	"math/rand"
+	"reflect"
 	"runtime"
 	"testing"
 )
@@ -31,7 +34,7 @@ func genTestDataBlocks(num int) []DataBlock {
 	return blocks
 }
 
-func TestMerkleTreeNew(t *testing.T) {
+func TestMerkleTreeNew_proofGen(t *testing.T) {
 	type args struct {
 		blocks []DataBlock
 		config *Config
@@ -46,6 +49,20 @@ func TestMerkleTreeNew(t *testing.T) {
 			args: args{
 				blocks: genTestDataBlocks(0),
 			},
+			wantErr: true,
+		},
+		{
+			name: "test_1",
+			args: args{
+				blocks: genTestDataBlocks(1),
+			},
+			wantErr: true,
+		},
+		{
+			name: "test_2",
+			args: args{
+				blocks: genTestDataBlocks(2),
+			},
 			wantErr: false,
 		},
 		{
@@ -59,10 +76,6 @@ func TestMerkleTreeNew(t *testing.T) {
 			name: "test_8",
 			args: args{
 				blocks: genTestDataBlocks(8),
-				config: &Config{
-					HashFunc:        defaultHashFunc,
-					AllowDuplicates: true,
-				},
 			},
 			wantErr: false,
 		},
@@ -70,10 +83,6 @@ func TestMerkleTreeNew(t *testing.T) {
 			name: "test_5",
 			args: args{
 				blocks: genTestDataBlocks(5),
-				config: &Config{
-					HashFunc:        defaultHashFunc,
-					AllowDuplicates: true,
-				},
 			},
 			wantErr: false,
 		},
@@ -89,10 +98,9 @@ func TestMerkleTreeNew(t *testing.T) {
 			args: args{
 				blocks: genTestDataBlocks(100),
 				config: &Config{
-					HashFunc:        defaultHashFunc,
-					AllowDuplicates: true,
-					RunInParallel:   true,
-					NumRoutines:     4,
+					HashFunc:      defaultHashFunc,
+					RunInParallel: true,
+					NumRoutines:   4,
 				},
 			},
 			wantErr: false,
@@ -107,11 +115,98 @@ func TestMerkleTreeNew(t *testing.T) {
 	}
 }
 
+func TestMerkleTreeNew_buildTree(t *testing.T) {
+	type args struct {
+		blocks []DataBlock
+		config *Config
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "test_build_tree_2",
+			args: args{
+				blocks: genTestDataBlocks(2),
+				config: &Config{
+					HashFunc: defaultHashFunc,
+					Mode:     ModeTreeBuild,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test_build_tree_4",
+			args: args{
+				blocks: genTestDataBlocks(4),
+				config: &Config{
+					HashFunc: defaultHashFunc,
+					Mode:     ModeTreeBuild,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test_build_tree_5",
+			args: args{
+				blocks: genTestDataBlocks(5),
+				config: &Config{
+					HashFunc: defaultHashFunc,
+					Mode:     ModeTreeBuild,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test_build_tree_8",
+			args: args{
+				blocks: genTestDataBlocks(8),
+				config: &Config{
+					HashFunc: defaultHashFunc,
+					Mode:     ModeTreeBuild,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test_build_tree_1000",
+			args: args{
+				blocks: genTestDataBlocks(1000),
+				config: &Config{
+					HashFunc: defaultHashFunc,
+					Mode:     ModeTreeBuild,
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := New(tt.args.config, tt.args.blocks)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Build() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			m1, err := New(nil, tt.args.blocks)
+			if err != nil {
+				t.Errorf("test setup error %v", err)
+				return
+			}
+			if !bytes.Equal(m.Root, m1.Root) {
+				fmt.Println("m", m.Root)
+				fmt.Println("m1", m1.Root)
+				t.Errorf("tree generated is wrong")
+				return
+			}
+		})
+	}
+}
+
 func verifySetup(size int) (*MerkleTree, []DataBlock, error) {
 	blocks := genTestDataBlocks(size)
 	m, err := New(&Config{
-		HashFunc:        defaultHashFunc,
-		AllowDuplicates: true,
+		HashFunc: defaultHashFunc,
 	}, blocks)
 	if err != nil {
 		return nil, nil, err
@@ -122,10 +217,9 @@ func verifySetup(size int) (*MerkleTree, []DataBlock, error) {
 func verifySetupParallel(size int) (*MerkleTree, []DataBlock, error) {
 	blocks := genTestDataBlocks(size)
 	m, err := New(&Config{
-		HashFunc:        defaultHashFunc,
-		AllowDuplicates: true,
-		RunInParallel:   true,
-		NumRoutines:     4,
+		HashFunc:      defaultHashFunc,
+		RunInParallel: true,
+		NumRoutines:   4,
 	}, blocks)
 	if err != nil {
 		return nil, nil, err
@@ -205,6 +299,13 @@ func TestMerkleTree_Verify(t *testing.T) {
 			wantErr:   false,
 		},
 		{
+			name:      "test_pseudo_random_64_parallel",
+			setupFunc: verifySetupParallel,
+			blockSize: 64,
+			want:      true,
+			wantErr:   false,
+		},
+		{
 			name:      "test_pseudo_random_1001_parallel",
 			setupFunc: verifySetupParallel,
 			blockSize: 1001,
@@ -248,8 +349,7 @@ func TestVerify(t *testing.T) {
 
 func BenchmarkMerkleTreeNew(b *testing.B) {
 	config := &Config{
-		HashFunc:        defaultHashFunc,
-		AllowDuplicates: true,
+		HashFunc: defaultHashFunc,
 	}
 	for i := 0; i < b.N; i++ {
 		_, err := New(config, genTestDataBlocks(benchSize))
@@ -261,15 +361,66 @@ func BenchmarkMerkleTreeNew(b *testing.B) {
 
 func BenchmarkMerkleTreeNewParallel(b *testing.B) {
 	config := &Config{
-		HashFunc:        defaultHashFunc,
-		AllowDuplicates: true,
-		RunInParallel:   true,
-		NumRoutines:     runtime.NumCPU(),
+		HashFunc:      defaultHashFunc,
+		RunInParallel: true,
+		NumRoutines:   runtime.NumCPU(),
 	}
 	for i := 0; i < b.N; i++ {
 		_, err := New(config, genTestDataBlocks(benchSize))
 		if err != nil {
 			b.Errorf("Build() error = %v", err)
 		}
+	}
+}
+
+func TestMerkleTree_GenerateProof(t *testing.T) {
+	tests := []struct {
+		name    string
+		blocks  []DataBlock
+		wantErr bool
+	}{
+		{
+			name:   "test_2",
+			blocks: genTestDataBlocks(2),
+		},
+		{
+			name:   "test_3",
+			blocks: genTestDataBlocks(3),
+		},
+		{
+			name:   "test_4",
+			blocks: genTestDataBlocks(4),
+		},
+		{
+			name:   "test_5",
+			blocks: genTestDataBlocks(5),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m1, err := New(nil, tt.blocks)
+			if err != nil {
+				t.Errorf("m1 New() error = %v", err)
+				return
+			}
+			m2, err := New(&Config{
+				Mode: ModeTreeBuild,
+			}, tt.blocks)
+			if err != nil {
+				t.Errorf("m2 New() error = %v", err)
+				return
+			}
+			for idx, block := range tt.blocks {
+				got, err := m2.GenerateProof(block)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("GenerateProof() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+				if !reflect.DeepEqual(got, m1.Proofs[idx]) {
+					t.Errorf("GenerateProof() %d got = %v, want %v", idx, got, m1.Proofs[idx])
+					return
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
The previous code's buildTree functions actually perform proof generations only, the whole Merkle Tree is not built and stored. However, it is necessary to keep the whole tree sometimes. For example, when you only needs the proofs of several data blocks, it is very costly to use the poof generation method to calculate the proofs for the whole set. So I implement the new tree building method, and defined three modes for Merkle Tree configuration:
- ModeProofGen: also the default mode, generates proofs only,
- ModeTreeBuild: builds up the Merkle Tree only, can use the Merke Tree to retrieve the proof of a certain data block,
- ModeProofGenAndTreeBuild: we have the first and the second, why not both 😜