### PR TITLE
Refactor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.19
 
 require (
 	github.com/agiledragon/gomonkey/v2 v2.8.0
-	github.com/txaty/gool v0.1.3
+	github.com/txaty/gool v0.1.4
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
-github.com/txaty/gool v0.1.3 h1:CuSpftgWpquulhJUTV/Ky28mN9kpc5hQGgX4Ck9qlDI=
-github.com/txaty/gool v0.1.3/go.mod h1:zhUnrAMYUZXRYBq6dTofbCUn8OgA3OOKCFMeqGV2mu0=
+github.com/txaty/gool v0.1.4 h1:3NwHLjdNsbITl3aqII8n8d4NYvOQE+3qt7cTLkeEAgM=
+github.com/txaty/gool v0.1.4/go.mod h1:zhUnrAMYUZXRYBq6dTofbCUn8OgA3OOKCFMeqGV2mu0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/merkle_tree_test.go
+++ b/merkle_tree_test.go
@@ -1049,25 +1049,31 @@ func Test_proofGenHandler(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 	type args struct {
-		argInterface interface{}
+		arg argType
+	}
+	mt, err := New(nil, genTestDataBlocks(5))
+	if err != nil {
+		t.Errorf("New() error = %v", err)
+		return
+	}
+	mt.HashFunc = func([]byte) ([]byte, error) {
+		return nil, errors.New("test_hash_func_err")
 	}
 	tests := []struct {
+		mock    func()
 		name    string
 		args    args
-		mock    func()
 		wantErr bool
 	}{
 		{
 			name: "test_hash_func_err",
 			args: args{
-				argInterface: &proofGenArgs{
-					hashFunc: func([]byte) ([]byte, error) {
-						return nil, errors.New("test_hash_func_err")
-					},
-					buf1:        [][]byte{[]byte("test_buf1"), []byte("test_buf1")},
-					buf2:        [][]byte{[]byte("test_buf2")},
-					prevLen:     2,
-					numRoutines: 2,
+				arg: argType{
+					mt:         mt,
+					byteField1: [][]byte{[]byte("test_buf1"), []byte("test_buf1")},
+					byteField2: [][]byte{[]byte("test_buf2")},
+					intField2:  2,
+					intField3:  2,
 				},
 			},
 			wantErr: true,
@@ -1079,7 +1085,7 @@ func Test_proofGenHandler(t *testing.T) {
 				tt.mock()
 			}
 			defer patches.Reset()
-			if err := proofGenHandler(tt.args.argInterface); (err != nil) != tt.wantErr {
+			if err := proofGenHandler(tt.args.arg); (err != nil) != tt.wantErr {
 				t.Errorf("proofGenHandler() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
1. Use general arg struct and return type to improve goroutine pool performance,
2. Order fields in structs for memory saving,
3. Gool (goroutine pool) version upgrade.

Signed-off-by: txaty <xtianae@connect.ust.hk>