### PR TITLE
Add support for OpenZeppelin sort-pair verifcation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/txaty/go-merkletree
 go 1.19
 
 require (
-	github.com/agiledragon/gomonkey/v2 v2.8.0
+	github.com/agiledragon/gomonkey/v2 v2.9.0
 	github.com/txaty/gool v0.1.4
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/agiledragon/gomonkey/v2 v2.8.0 h1:u2K2nNGyk0ippzklz1CWalllEB9ptD+DtSXeCX5O000=
-github.com/agiledragon/gomonkey/v2 v2.8.0/go.mod h1:ap1AmDzcVOAz1YpeJ3TCzIgstoaWLA6jbbgxfB4w2iY=
+github.com/agiledragon/gomonkey/v2 v2.9.0 h1:PDiKKybR596O6FHW+RVSG0Z7uGCBNbmbUXh3uCNQ7Hc=
+github.com/agiledragon/gomonkey/v2 v2.9.0/go.mod h1:ap1AmDzcVOAz1YpeJ3TCzIgstoaWLA6jbbgxfB4w2iY=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=

--- a/merkle_tree.go
+++ b/merkle_tree.go
@@ -669,6 +669,10 @@ func Verify(dataBlock DataBlock, proof *Proof, root []byte, config *Config) (boo
 		config.HashFunc = defaultHashFunc
 	}
 
+	if config.concatHashFunc == nil {
+		config.concatHashFunc = concatHash
+	}
+
 	var (
 		data, err = dataBlock.Serialize()
 		hash      []byte

--- a/merkle_tree_test.go
+++ b/merkle_tree_test.go
@@ -30,7 +30,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
-
+	
 	"github.com/agiledragon/gomonkey/v2"
 )
 
@@ -1033,7 +1033,9 @@ func TestVerify(t *testing.T) {
 				tt.mock()
 			}
 			defer patches.Reset()
-			got, err := Verify(tt.args.dataBlock, tt.args.proof, tt.args.root, tt.args.hashFunc)
+			got, err := Verify(tt.args.dataBlock, tt.args.proof, tt.args.root, &Config{
+				HashFunc: tt.args.hashFunc,
+			})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Verify() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/merkle_tree_test.go
+++ b/merkle_tree_test.go
@@ -156,6 +156,16 @@ func TestMerkleTreeNew_proofGen(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "test_8_sorted",
+			args: args{
+				blocks: genTestDataBlocks(8),
+				config: &Config{
+					SortSiblingPairs: true,
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "test_hash_func_error",
 			args: args{
 				blocks: genTestDataBlocks(100),

--- a/merkle_tree_test.go
+++ b/merkle_tree_test.go
@@ -925,7 +925,7 @@ func TestVerify(t *testing.T) {
 		proof          *Proof
 		root           []byte
 		hashFunc       HashFuncType
-		concatHashFunc concatFuncType
+		concatHashFunc concatHashFuncType
 	}
 	tests := []struct {
 		name    string


### PR DESCRIPTION
Add SortSiblingPair parameter in Config for OpenZeppelin support:
- If it is set to true, then the sibling hash pairs are first sorted in ascending order, and then concatenated.
- Otherwise, no change.

This PR is originated from https://github.com/txaty/go-merkletree/pull/20 by user [dev-ubq](https://github.com/dev-ubq).